### PR TITLE
Feature/create transaction

### DIFF
--- a/src/main/java/com/fedelizondo/challenge/application/port/in/CreateTransactionUseCase.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/in/CreateTransactionUseCase.java
@@ -1,0 +1,8 @@
+package com.fedelizondo.challenge.application.port.in;
+
+import com.fedelizondo.challenge.dominio.model.Transaction;
+
+@FunctionalInterface
+public interface CreateTransactionUseCase {
+    Transaction createTransaction(Transaction transaction);
+}

--- a/src/main/java/com/fedelizondo/challenge/application/port/out/FindByIdTransactionUseCaseOut.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/out/FindByIdTransactionUseCaseOut.java
@@ -1,0 +1,9 @@
+package com.fedelizondo.challenge.application.port.out;
+
+import com.fedelizondo.challenge.dominio.model.Transaction;
+
+import java.util.Optional;
+
+public interface FindByIdTransactionUseCaseOut {
+    Optional<Transaction> findById(Long id);
+}

--- a/src/main/java/com/fedelizondo/challenge/application/port/out/SaveTransactionUseCaseOut.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/out/SaveTransactionUseCaseOut.java
@@ -1,0 +1,7 @@
+package com.fedelizondo.challenge.application.port.out;
+
+import com.fedelizondo.challenge.dominio.model.Transaction;
+
+public interface SaveTransactionUseCaseOut {
+    Transaction save(Transaction transaction);
+}

--- a/src/main/java/com/fedelizondo/challenge/application/service/CreateTransactionUseCaseImpl.java
+++ b/src/main/java/com/fedelizondo/challenge/application/service/CreateTransactionUseCaseImpl.java
@@ -1,0 +1,30 @@
+package com.fedelizondo.challenge.application.service;
+
+import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
+import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
+import com.fedelizondo.challenge.application.port.out.SaveTransactionUseCaseOut;
+import com.fedelizondo.challenge.dominio.exception.TransactionAlreadyExistException;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CreateTransactionUseCaseImpl implements CreateTransactionUseCase {
+
+    private final FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut;
+    private final SaveTransactionUseCaseOut saveTransactionUseCaseOut;
+
+    public CreateTransactionUseCaseImpl(FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut, SaveTransactionUseCaseOut saveTransactionUseCaseOut) {
+        this.findByIdTransactionUseCaseOut = findByIdTransactionUseCaseOut;
+        this.saveTransactionUseCaseOut = saveTransactionUseCaseOut;
+    }
+
+    @Override
+    public Transaction createTransaction(Transaction transaction) {
+        Transaction searchTransaction = findByIdTransactionUseCaseOut.findById(transaction.id()).orElse(null);
+        if (searchTransaction != null) {
+            throw new TransactionAlreadyExistException();
+        }
+
+        return saveTransactionUseCaseOut.save(transaction);
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/dominio/exception/TransactionAlreadyExistException.java
+++ b/src/main/java/com/fedelizondo/challenge/dominio/exception/TransactionAlreadyExistException.java
@@ -1,0 +1,7 @@
+package com.fedelizondo.challenge.dominio.exception;
+
+public class TransactionAlreadyExistException extends RuntimeException {
+    public TransactionAlreadyExistException() {
+        super("Transaction already exist");
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/dominio/model/Transaction.java
+++ b/src/main/java/com/fedelizondo/challenge/dominio/model/Transaction.java
@@ -1,4 +1,4 @@
 package com.fedelizondo.challenge.dominio.model;
 
-public record Transaction(Long id, double amount, String type, Long ParentId) {
+public record Transaction(Long id, double amount, String type, Long parentId) {
 }

--- a/src/main/java/com/fedelizondo/challenge/dominio/model/Transaction.java
+++ b/src/main/java/com/fedelizondo/challenge/dominio/model/Transaction.java
@@ -1,0 +1,4 @@
+package com.fedelizondo.challenge.dominio.model;
+
+public record Transaction(Long id, double amount, String type, Long ParentId) {
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionController.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionController.java
@@ -1,0 +1,41 @@
+package com.fedelizondo.challenge.infrastructure.adapter.in.rest.controller;
+
+import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import com.fedelizondo.challenge.infrastructure.adapter.in.rest.request.TransactionRequest;
+import com.fedelizondo.challenge.infrastructure.adapter.in.rest.response.TransactionResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/transactions")
+public class TransactionController {
+
+    private final CreateTransactionUseCase createTransactionUseCase;
+
+    public TransactionController(CreateTransactionUseCase createTransactionUseCase) {
+        this.createTransactionUseCase = createTransactionUseCase;
+    }
+
+    @PutMapping("/{transactionId}")
+    public ResponseEntity<TransactionResponse> saveTransaction(@PathVariable long transactionId, @Valid @RequestBody TransactionRequest transactionRequest) {
+
+        Transaction transaction = new Transaction(
+                transactionId,
+                transactionRequest.getAmount(),
+                transactionRequest.getType(),
+                transactionRequest.getParentId()
+        );
+
+        Transaction savedTransaction = createTransactionUseCase.createTransaction(transaction);
+
+        return ResponseEntity.ok(
+                new TransactionResponse(
+                        savedTransaction.id(),
+                        savedTransaction.amount(),
+                        savedTransaction.type(),
+                        savedTransaction.parentId())
+        );
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/request/TransactionRequest.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/request/TransactionRequest.java
@@ -1,0 +1,34 @@
+package com.fedelizondo.challenge.infrastructure.adapter.in.rest.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public class TransactionRequest {
+    @Min(0)
+    private final double amount;
+
+    @NotBlank
+    private final String type;
+
+    @JsonProperty("parent_id")
+    private final Long parentId;
+
+    public TransactionRequest(double amount, String type, Long parentId) {
+        this.amount = amount;
+        this.type = type;
+        this.parentId = parentId;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/response/TransactionResponse.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/response/TransactionResponse.java
@@ -1,0 +1,37 @@
+package com.fedelizondo.challenge.infrastructure.adapter.in.rest.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TransactionResponse {
+    @JsonProperty("transaction_id")
+    private final long transactionId;
+    private final double amount;
+    private final String type;
+    @JsonProperty("parent_id")
+    private final Long parentId;
+
+    public TransactionResponse(long transactionId, double amount, String type, Long parentId) {
+        this.transactionId = transactionId;
+        this.amount = amount;
+        this.type = type;
+        this.parentId = parentId;
+    }
+
+    public long getTransactionId() {
+        return transactionId;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/entity/TransactionEntity.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/entity/TransactionEntity.java
@@ -1,0 +1,41 @@
+package com.fedelizondo.challenge.infrastructure.adapter.out.persistence.memory.entity;
+
+public class TransactionEntity {
+    private long transactionId;
+    private double amount;
+    private String type;
+    private Long parentId;
+    private double total;
+
+    public TransactionEntity(long transactionId, double amount, String type, Long parentId) {
+        this.transactionId = transactionId;
+        this.amount = amount;
+        this.type = type;
+        this.parentId = parentId;
+        this.total = amount;
+    }
+
+    public long getTransactionId() {
+        return transactionId;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Long getParentId() {
+        return parentId;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public void addTotal(double amount) {
+        total += amount;
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepository.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepository.java
@@ -1,0 +1,34 @@
+package com.fedelizondo.challenge.infrastructure.adapter.out.persistence.memory.repository;
+
+import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
+import com.fedelizondo.challenge.application.port.out.SaveTransactionUseCaseOut;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import com.fedelizondo.challenge.infrastructure.adapter.out.persistence.memory.entity.TransactionEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class TransactionRepository implements FindByIdTransactionUseCaseOut, SaveTransactionUseCaseOut {
+
+    private static final ConcurrentHashMap<Long, TransactionEntity> transactions = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<Transaction> findById(Long id) {
+        return Optional.ofNullable (transactions.get(id)).map(entity ->
+                new Transaction(id, entity.getAmount(), entity.getType(), entity.getParentId())
+        );
+    }
+
+    @Override
+    public Transaction save(Transaction transaction) {
+        TransactionEntity transactionEntity = new TransactionEntity(transaction.id(), transaction.amount(), transaction.type(), transaction.parentId());
+        transactions.putIfAbsent(transactionEntity.getTransactionId(), transactionEntity);
+        return new Transaction(transactionEntity.getTransactionId(), transactionEntity.getAmount(), transactionEntity.getType(), transactionEntity.getParentId());
+    }
+
+    public static void clearData(){
+        transactions.clear();
+    }
+}

--- a/src/test/java/com/fedelizondo/challenge/application/service/CreateTransactionUseCaseImplTest.java
+++ b/src/test/java/com/fedelizondo/challenge/application/service/CreateTransactionUseCaseImplTest.java
@@ -1,0 +1,64 @@
+package com.fedelizondo.challenge.application.service;
+
+import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
+import com.fedelizondo.challenge.application.port.out.SaveTransactionUseCaseOut;
+import com.fedelizondo.challenge.dominio.exception.TransactionAlreadyExistException;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CreateTransactionUseCaseImplTest {
+
+    CreateTransactionUseCaseImpl createTransactionUseCase;
+    SaveTransactionUseCaseOut saveTransactionUseCaseOut;
+    FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut;
+
+    @BeforeEach
+    void setUp() {
+        saveTransactionUseCaseOut = mock(SaveTransactionUseCaseOut.class);
+        findByIdTransactionUseCaseOut = mock(FindByIdTransactionUseCaseOut.class);
+        createTransactionUseCase = new CreateTransactionUseCaseImpl(findByIdTransactionUseCaseOut, saveTransactionUseCaseOut);
+    }
+
+    @Test
+    void givenExistingIdWhenCreateTransactionThenThrowTransactionAlreadyExistException() {
+        //Arrange
+        Transaction transaction = new Transaction(1L, 0, "test", null);
+        Transaction existingTransaction = new Transaction(1L, 0, "existing", null);
+
+        when(findByIdTransactionUseCaseOut.findById(transaction.id())).thenReturn(Optional.of(existingTransaction));
+
+        //Act
+        Exception exception = assertThrows(TransactionAlreadyExistException.class, () -> {
+            createTransactionUseCase.createTransaction(transaction);
+        });
+
+        //Assert
+        assertEquals("Transaction already exist", exception.getMessage());
+    }
+
+    @Test
+    void givenNewTransactionWhenCreateTransactionThenReturnNewTransaction() {
+        //Arrange
+        Transaction transaction = new Transaction(1L, 0, "test", null);
+        Transaction newTransaction = new Transaction(1L, 0, "existing", null);
+
+        when(findByIdTransactionUseCaseOut.findById(transaction.id())).thenReturn(Optional.empty());
+        when(saveTransactionUseCaseOut.save(transaction)).thenReturn(newTransaction);
+
+        //Act
+        Transaction subject = createTransactionUseCase.createTransaction(transaction);
+
+        //Assert
+        assertEquals(newTransaction.id(), subject.id());
+        assertEquals(newTransaction.amount(), subject.amount());
+        assertEquals(newTransaction.type(), subject.type());
+        assertEquals(newTransaction.parentId(), subject.parentId());
+    }
+}

--- a/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionControllerTest.java
+++ b/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionControllerTest.java
@@ -1,0 +1,54 @@
+package com.fedelizondo.challenge.infrastructure.adapter.in.rest.controller;
+
+import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import com.fedelizondo.challenge.infrastructure.adapter.in.rest.request.TransactionRequest;
+import com.fedelizondo.challenge.infrastructure.adapter.in.rest.response.TransactionResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TransactionControllerTest {
+
+    TransactionController transactionController;
+    CreateTransactionUseCase createTransactionUseCase;
+
+    @BeforeEach
+    void setUp() {
+        createTransactionUseCase = mock(CreateTransactionUseCase.class);
+        transactionController = new TransactionController(createTransactionUseCase);
+    }
+
+
+    @Test
+    void givenNewTransactionWhenSaveTransactionThenReturn200(){
+
+        long transactionId = 1L;
+        double amount = 100.00;
+        String type = "income";
+        Long parentId = null;
+
+        TransactionRequest transactionRequest = new TransactionRequest(amount, type, parentId);
+        Transaction expectedSavedTransaction = new Transaction(transactionId, amount, type, parentId);
+
+        when(createTransactionUseCase.createTransaction(expectedSavedTransaction)).thenReturn(expectedSavedTransaction);
+
+        // When (Act)
+        ResponseEntity<TransactionResponse> response = transactionController.saveTransaction(transactionId, transactionRequest);
+
+        // Then (Assert)
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        TransactionResponse actualTransactionResponse = response.getBody();
+
+        assertEquals(transactionId, actualTransactionResponse.getTransactionId());
+        assertEquals(amount, actualTransactionResponse.getAmount());
+        assertEquals(type, actualTransactionResponse.getType());
+        assertEquals(parentId, actualTransactionResponse.getParentId());
+
+    }
+}

--- a/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepositoryTest.java
@@ -1,0 +1,61 @@
+package com.fedelizondo.challenge.infrastructure.adapter.out.persistence.memory.repository;
+
+import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import com.fedelizondo.challenge.infrastructure.adapter.in.rest.controller.TransactionController;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class TransactionRepositoryTest {
+
+    TransactionRepository transactionRepository;
+
+    @BeforeEach
+    void setUp() {
+        transactionRepository = new TransactionRepository();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionRepository.clearData();
+    }
+
+    @Test
+    void givenExistingIdWhenFindByIdThenReturnTransaction() {
+        //Arrange
+        Long findId = 1L;
+        double amount = 10;
+        String type = "test";
+        Long parentId = null;
+        Transaction transaction = new Transaction(findId, amount, type, parentId);
+        transactionRepository.save(transaction);
+
+        //Act
+        Transaction subject = transactionRepository.findById(findId).orElse(null);
+
+        //Assert
+        assertEquals(findId, subject.id());
+        assertEquals(amount, subject.amount());
+        assertEquals(type, subject.type());
+        assertEquals(parentId, subject.parentId());
+    }
+
+    @Test
+    void givenNotExistingIdWhenFindByIdThenReturnTransaction() {
+        //Arrange
+        Long findId = 1L;
+        double amount = 10;
+        String type = "test";
+        Long parentId = null;
+
+        //Act
+        Transaction subject = transactionRepository.findById(findId).orElse(null);
+
+        //Assert
+        assertNull(subject);
+    }
+}


### PR DESCRIPTION
Se agrega la funcionalidad de crear una transacción con un put, 
Estoy asumiendo que no se esta cumpliendo como se espera con una api rest, de crear el recurso con el post y se crea con el put, esto es por el enunciado  
Se puede cambiar las validaciones, por ejemplo de que exista a que no exista 