### PR TITLE
Feature/get sum of transaction

### DIFF
--- a/src/main/java/com/fedelizondo/challenge/application/port/in/GetCumulativeSumTransactionUseCase.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/in/GetCumulativeSumTransactionUseCase.java
@@ -1,0 +1,5 @@
+package com.fedelizondo.challenge.application.port.in;
+
+public interface GetCumulativeSumTransactionUseCase {
+    double getCumulativeSumForTransaction(Long id);
+}

--- a/src/main/java/com/fedelizondo/challenge/application/port/in/GetCumulativeSumTransactionUseCase.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/in/GetCumulativeSumTransactionUseCase.java
@@ -1,5 +1,6 @@
 package com.fedelizondo.challenge.application.port.in;
 
+@FunctionalInterface
 public interface GetCumulativeSumTransactionUseCase {
     double getCumulativeSumForTransaction(Long id);
 }

--- a/src/main/java/com/fedelizondo/challenge/application/port/out/GetCumulativeSumForTransactionUseCaseOut.java
+++ b/src/main/java/com/fedelizondo/challenge/application/port/out/GetCumulativeSumForTransactionUseCaseOut.java
@@ -1,0 +1,5 @@
+package com.fedelizondo.challenge.application.port.out;
+
+public interface GetCumulativeSumForTransactionUseCaseOut {
+    double getCumulativeSumForTransaction(Long transactionId);
+}

--- a/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
+++ b/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
@@ -4,7 +4,9 @@ import com.fedelizondo.challenge.application.port.in.GetCumulativeSumTransaction
 import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
 import com.fedelizondo.challenge.application.port.out.GetCumulativeSumForTransactionUseCaseOut;
 import com.fedelizondo.challenge.dominio.model.Transaction;
+import org.springframework.stereotype.Service;
 
+@Service
 public class GetCumulativeSumTransactionUseCaseImpl implements GetCumulativeSumTransactionUseCase {
 
     private final GetCumulativeSumForTransactionUseCaseOut getCumulativeSumForTransactionUseCaseOut;

--- a/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
+++ b/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
@@ -1,0 +1,29 @@
+package com.fedelizondo.challenge.application.service;
+
+import com.fedelizondo.challenge.application.port.in.GetCumulativeSumTransactionUseCase;
+import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
+import com.fedelizondo.challenge.application.port.out.GetCumulativeSumForTransactionUseCaseOut;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+
+public class GetCumulativeSumTransactionUseCaseImpl implements GetCumulativeSumTransactionUseCase {
+
+    private final GetCumulativeSumForTransactionUseCaseOut getCumulativeSumForTransactionUseCaseOut;
+    private final FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut;
+
+    public GetCumulativeSumTransactionUseCaseImpl(
+            GetCumulativeSumForTransactionUseCaseOut getCumulativeSumForTransactionUseCaseOut,
+            FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut
+    ) {
+        this.getCumulativeSumForTransactionUseCaseOut = getCumulativeSumForTransactionUseCaseOut;
+        this.findByIdTransactionUseCaseOut = findByIdTransactionUseCaseOut;
+    }
+
+    @Override
+    public double getCumulativeSumForTransaction(Long id) {
+        Transaction transaction = findByIdTransactionUseCaseOut.findById(id).orElse(null);
+        if(transaction == null ) {
+            return 0;
+        }
+        return getCumulativeSumForTransactionUseCaseOut.getCumulativeSumForTransaction(id);
+    }
+}

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionController.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionController.java
@@ -2,6 +2,7 @@ package com.fedelizondo.challenge.infrastructure.adapter.in.rest.controller;
 
 import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
 import com.fedelizondo.challenge.application.port.in.FindTransactionIdsByTypeUseCase;
+import com.fedelizondo.challenge.application.port.in.GetCumulativeSumTransactionUseCase;
 import com.fedelizondo.challenge.dominio.model.Transaction;
 import com.fedelizondo.challenge.infrastructure.adapter.in.rest.request.TransactionRequest;
 import com.fedelizondo.challenge.infrastructure.adapter.in.rest.response.TransactionResponse;
@@ -19,10 +20,12 @@ public class TransactionController {
 
     private final CreateTransactionUseCase createTransactionUseCase;
     private final FindTransactionIdsByTypeUseCase findTransactionIdsByTypeUseCase;
+    private final GetCumulativeSumTransactionUseCase getCumulativeSumTransactionUseCase;
 
-    public TransactionController(CreateTransactionUseCase createTransactionUseCase, FindTransactionIdsByTypeUseCase findTransactionIdsByTypeUseCase) {
+    public TransactionController(CreateTransactionUseCase createTransactionUseCase, FindTransactionIdsByTypeUseCase findTransactionIdsByTypeUseCase, GetCumulativeSumTransactionUseCase getCumulativeSumTransactionUseCase) {
         this.createTransactionUseCase = createTransactionUseCase;
         this.findTransactionIdsByTypeUseCase = findTransactionIdsByTypeUseCase;
+        this.getCumulativeSumTransactionUseCase = getCumulativeSumTransactionUseCase;
     }
 
     @PutMapping("/{transactionId}")
@@ -49,5 +52,10 @@ public class TransactionController {
     @GetMapping("/types/{type}")
     public ResponseEntity<List<Long>> findTransactionByType(@NotBlank @PathVariable String type) {
         return ResponseEntity.ok(findTransactionIdsByTypeUseCase.findTransactionByType(type.toLowerCase(Locale.ROOT)));
+    }
+
+    @GetMapping("/sum/{transactionId}")
+    public ResponseEntity<Double> getTransactionSum(@PathVariable Long transactionId) {
+        return ResponseEntity.ok(getCumulativeSumTransactionUseCase.getCumulativeSumForTransaction(transactionId));
     }
 }

--- a/src/test/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImplTest.java
+++ b/src/test/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImplTest.java
@@ -1,0 +1,60 @@
+package com.fedelizondo.challenge.application.service;
+
+import com.fedelizondo.challenge.application.port.out.FindByIdTransactionUseCaseOut;
+import com.fedelizondo.challenge.application.port.out.GetCumulativeSumForTransactionUseCaseOut;
+import com.fedelizondo.challenge.dominio.model.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GetCumulativeSumTransactionUseCaseImplTest {
+
+    GetCumulativeSumTransactionUseCaseImpl getCumulativeSumTransactionUseCaseImpl;
+    GetCumulativeSumForTransactionUseCaseOut getCumulativeSumForTransactionUseCaseOut;
+    FindByIdTransactionUseCaseOut findByIdTransactionUseCaseOut;
+
+    @BeforeEach
+    void setUp() {
+        getCumulativeSumForTransactionUseCaseOut = mock(GetCumulativeSumForTransactionUseCaseOut.class);
+        findByIdTransactionUseCaseOut = mock(FindByIdTransactionUseCaseOut.class);
+        getCumulativeSumTransactionUseCaseImpl = new GetCumulativeSumTransactionUseCaseImpl(
+                getCumulativeSumForTransactionUseCaseOut,
+                findByIdTransactionUseCaseOut
+        );
+    }
+
+
+    @Test
+    void givenInvalidIdWhenGetCumulativeSumThenReturnO(){
+        //Arrange
+        Long invalid = 1337L;
+        when(findByIdTransactionUseCaseOut.findById(invalid)).thenReturn(Optional.empty());
+
+        //Act
+        double subject = getCumulativeSumTransactionUseCaseImpl.getCumulativeSumForTransaction(invalid);
+
+        //Assert
+        assertEquals(0, subject);
+    }
+
+
+    @Test
+    void givenValidIdWhenGetCumulativeSumThenReturnNumber(){
+        //Arrange
+        Long invalid = 1337L;
+        Transaction transaction = new Transaction(invalid,10,"test",null);
+        when(findByIdTransactionUseCaseOut.findById(invalid)).thenReturn(Optional.of(transaction));
+        when(getCumulativeSumForTransactionUseCaseOut.getCumulativeSumForTransaction(invalid)).thenReturn(10D);
+
+        //Act
+        double subject = getCumulativeSumTransactionUseCaseImpl.getCumulativeSumForTransaction(invalid);
+
+        //Assert
+        assertEquals(10D, subject);
+    }
+}

--- a/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionControllerTest.java
+++ b/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/in/rest/controller/TransactionControllerTest.java
@@ -2,6 +2,7 @@ package com.fedelizondo.challenge.infrastructure.adapter.in.rest.controller;
 
 import com.fedelizondo.challenge.application.port.in.CreateTransactionUseCase;
 import com.fedelizondo.challenge.application.port.in.FindTransactionIdsByTypeUseCase;
+import com.fedelizondo.challenge.application.port.in.GetCumulativeSumTransactionUseCase;
 import com.fedelizondo.challenge.dominio.model.Transaction;
 import com.fedelizondo.challenge.infrastructure.adapter.in.rest.request.TransactionRequest;
 import com.fedelizondo.challenge.infrastructure.adapter.in.rest.response.TransactionResponse;
@@ -13,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.List;
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,14 +23,19 @@ class TransactionControllerTest {
     TransactionController transactionController;
     CreateTransactionUseCase createTransactionUseCase;
     FindTransactionIdsByTypeUseCase findTransactionIdsByTypeUseCase;
+    GetCumulativeSumTransactionUseCase getCumulativeSumTransactionUseCase;
 
     @BeforeEach
     void setUp() {
         createTransactionUseCase = mock(CreateTransactionUseCase.class);
         findTransactionIdsByTypeUseCase = mock(FindTransactionIdsByTypeUseCase.class);
-        transactionController = new TransactionController(createTransactionUseCase, findTransactionIdsByTypeUseCase);
+        getCumulativeSumTransactionUseCase = mock(GetCumulativeSumTransactionUseCase.class);
+        transactionController = new TransactionController(
+                createTransactionUseCase,
+                findTransactionIdsByTypeUseCase,
+                getCumulativeSumTransactionUseCase
+        );
     }
-
 
     @Test
     void givenNewTransactionWhenSaveTransactionThenReturn200() {
@@ -72,6 +78,22 @@ class TransactionControllerTest {
         List<Long> ids = response.getBody();
         assertEquals(1, ids.size());
         assertEquals(1L, ids.get(0));
+    }
+
+    @Test
+    void givenValidIdWhenGetTransactionSumThenReturnSum() {
+        //Arrange
+        Long search = 1L;
+        when(getCumulativeSumTransactionUseCase.getCumulativeSumForTransaction(search)).thenReturn(10D);
+
+        //Act
+        ResponseEntity<Double> response = transactionController.getTransactionSum(search);
+
+        //Assert
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        Double sum = response.getBody();
+
+        assertEquals(10D, sum);
     }
 
 }

--- a/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepositoryTest.java
@@ -109,4 +109,39 @@ class TransactionRepositoryTest {
         assertTrue(subject.isEmpty());
     }
 
+    @Test
+    void givenExistingTransactionWhenGetCumulativeSumThenReturnListOfTransactions() {
+        //Arrange
+        Long findId = 1L;
+        double amount = 10;
+        String type = "test";
+        Long parentId = null;
+        Transaction transaction = new Transaction(findId, amount, type, parentId);
+        transactionRepository.save(transaction);
+
+        //Act
+        double subject = transactionRepository.getCumulativeSumForTransaction(findId);
+
+        //Assert
+        assertEquals(10D, subject);
+    }
+
+
+    @Test
+    void givenMultipleExistingTransactionWhenGetCumulativeSumThenReturnListOfTransactions() {
+        //Arrange
+        Long findId = 1L;
+        double amount = 10;
+        String type = "test";
+        Long parentId = null;
+        transactionRepository.save(new Transaction(findId, amount, type, parentId));
+        transactionRepository.save(new Transaction(2L, amount, type, findId));
+
+        //Act
+        double subject = transactionRepository.getCumulativeSumForTransaction(findId);
+
+        //Assert
+        assertEquals(20D, subject);
+    }
+
 }


### PR DESCRIPTION
Se agrega la funcionalidad de calcular la suma acumulativa de un padre con todos los nodos hijos 
La única consideración a realizar, se asume que siempre se agrega primero el padre antes que los hijos
En caso de no ser así, es necesario cambiar en repository la forma en que se agrega el total o se calcula