### PR TITLE
Refactor to apply single responsability principle in repository

### DIFF
--- a/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
+++ b/src/main/java/com/fedelizondo/challenge/application/service/GetCumulativeSumTransactionUseCaseImpl.java
@@ -23,7 +23,7 @@ public class GetCumulativeSumTransactionUseCaseImpl implements GetCumulativeSumT
     @Override
     public double getCumulativeSumForTransaction(Long id) {
         Transaction transaction = findByIdTransactionUseCaseOut.findById(id).orElse(null);
-        if(transaction == null ) {
+        if (transaction == null) {
             return 0;
         }
         return getCumulativeSumForTransactionUseCaseOut.getCumulativeSumForTransaction(id);

--- a/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepository.java
+++ b/src/main/java/com/fedelizondo/challenge/infrastructure/adapter/out/persistence/memory/repository/TransactionRepository.java
@@ -56,24 +56,26 @@ public class TransactionRepository implements
         return transactions.get(transactionId).getTotal();
     }
 
-    public static void clearData() {
-        transactions.clear();
-        types.clear();
-    }
-
-    public static void saveType(String type, TransactionEntity entity) {
+    private static void saveType(String type, TransactionEntity entity) {
         types.putIfAbsent(type, new ArrayList<>());
         types.get(type).add(entity);
     }
 
-    public static void saveTransactionEntity(TransactionEntity transaction) {
+    private static void saveTransactionEntity(TransactionEntity transaction) {
         transactions.putIfAbsent(transaction.getTransactionId(), transaction);
+        updateAmountInParents(transaction.getParentId(), transaction.getAmount());
+    }
 
-        Long parent = transaction.getParentId();
+    private static void updateAmountInParents(Long parent, double amount) {
         while (parent != null && transactions.containsKey(parent)) {
             TransactionEntity parentEntity = transactions.get(parent);
-            parentEntity.addTotal(transaction.getAmount());
+            parentEntity.addTotal(amount);
             parent = parentEntity.getParentId();
         }
+    }
+
+    public static void clearData() {
+        transactions.clear();
+        types.clear();
     }
 }


### PR DESCRIPTION
Se modifica el método saveTransactionEntity, para que este alineado al principio de responsabilidad única, se puede mover la lógica a un método para la actualización de los totales de las transacciones "padres".